### PR TITLE
Add LineGraph

### DIFF
--- a/presentation/component/src/commonMain/kotlin/com/shunm/android/presentation/component/graph/LineGraph.kt
+++ b/presentation/component/src/commonMain/kotlin/com/shunm/android/presentation/component/graph/LineGraph.kt
@@ -91,8 +91,6 @@ class LineGraphContextBuilder {
 
     var scaleCount: Int = 10
 
-    var yScaleSpace: Dp = 32.dp
-
     fun plot(x: Float, y: Float) {
         points.add(LineGraphPoint(x, y))
     }
@@ -126,7 +124,7 @@ fun rememberLineGraphContext(
 }
 
 @Composable
-fun ListGraph(
+fun LineGraph(
     context: LineGraphContext,
     containerColor: Color = MaterialTheme.colorScheme.surface,
     contentColor: Color = MaterialTheme.colorScheme.onSurface,
@@ -137,14 +135,14 @@ fun ListGraph(
     yScaleSpace: Dp = 32.dp,
 ) {
     with(context) {
-        ListGraphOuter(
+        LineGraphOuter(
             containerColor = containerColor,
             contentColor = contentColor,
             borderColor = borderColor,
             borderWidth = borderWidth,
             yScaleSpace = yScaleSpace,
         ) {
-            ListGraphInner(
+            LineGraphInner(
                 lineColor = lineColor,
                 lineWidth = lineWidth,
             )
@@ -154,7 +152,7 @@ fun ListGraph(
 
 @Composable
 context(context: LineGraphContext)
-private fun ListGraphOuter(
+private fun LineGraphOuter(
     containerColor: Color,
     contentColor: Color,
     borderColor: Color,
@@ -201,7 +199,7 @@ private fun ListGraphOuter(
 
 @Composable
 context(context: LineGraphContext)
-private fun ListGraphInner(
+private fun LineGraphInner(
     lineColor: Color,
     lineWidth: Dp,
 ) {
@@ -371,7 +369,7 @@ private fun ListGraphPreview() {
             y = listOf(0f, 1f, 64f, 4f, 100f, 16f, 25f, 9f, 36f, 49f, 81f),
         )
     }
-    ListGraph(
+    LineGraph(
         context = context,
     )
 }

--- a/presentation/component/src/commonMain/kotlin/com/shunm/android/presentation/component/graph/LineGraph.kt
+++ b/presentation/component/src/commonMain/kotlin/com/shunm/android/presentation/component/graph/LineGraph.kt
@@ -1,0 +1,38 @@
+package com.shunm.android.presentation.component.graph
+
+data class LineGraphPoint(
+    val x: Float,
+    val y: Float,
+)
+
+data class LineGraphContext(
+    val title: String?,
+    val xLabel: String?,
+    val yLabel: String?,
+    val points: List<LineGraphPoint>,
+)
+
+class LineGraphContextBuilder {
+    var title: String? = null
+    var xLabel: String? = null
+    var yLabel: String? = null
+    val points: MutableList<LineGraphPoint> = mutableListOf()
+
+    fun plot(x: Float, y: Float) {
+        points.add(LineGraphPoint(x, y))
+    }
+
+    fun plot(x: List<Float>, y: List<Float>) {
+        val size = minOf(x.size, y.size)
+        for (i in 0 until size) {
+            points.add(LineGraphPoint(x[i], y[i]))
+        }
+    }
+
+    fun build(): LineGraphContext = LineGraphContext(
+        title = title,
+        xLabel = xLabel,
+        yLabel = yLabel,
+        points = points.toList(),
+    )
+}

--- a/presentation/component/src/commonMain/kotlin/com/shunm/android/presentation/component/graph/LineGraph.kt
+++ b/presentation/component/src/commonMain/kotlin/com/shunm/android/presentation/component/graph/LineGraph.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
@@ -20,9 +21,10 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.drawBehind
-import androidx.compose.ui.draw.rotate
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Path
+import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.text.drawText
 import androidx.compose.ui.text.rememberTextMeasurer
 import androidx.compose.ui.text.style.TextAlign
@@ -129,6 +131,7 @@ fun ListGraph(
     containerColor: Color = MaterialTheme.colorScheme.surface,
     contentColor: Color = MaterialTheme.colorScheme.onSurface,
     lineColor: Color = MaterialTheme.colorScheme.primary,
+    lineWidth: Dp = 2.dp,
     borderColor: Color = MaterialTheme.colorScheme.onSurface,
     borderWidth: Dp = 1.dp,
     yScaleSpace: Dp = 32.dp,
@@ -141,6 +144,10 @@ fun ListGraph(
             borderWidth = borderWidth,
             yScaleSpace = yScaleSpace,
         ) {
+            ListGraphInner(
+                lineColor = lineColor,
+                lineWidth = lineWidth,
+            )
         }
     }
 }
@@ -189,6 +196,41 @@ private fun ListGraphOuter(
                 )
             }
         }
+    }
+}
+
+@Composable
+context(context: LineGraphContext)
+private fun ListGraphInner(
+    lineColor: Color,
+    lineWidth: Dp,
+) {
+    Box(
+        Modifier.fillMaxSize()
+            .drawBehind {
+                val path = Path().apply {
+                    context.points.forEachIndexed { index, point ->
+                        val xPercent = (point.x - context.xRange.start) / (context.xRange.endInclusive - context.xRange.start)
+                        val yPercent = (point.y - context.yRange.start) / (context.yRange.endInclusive - context.yRange.start)
+                        val x = 16.dp.toPx() + (xPercent * (size.width - (16.dp.toPx() * 2)))
+                        val y = size.height - (8.dp.toPx() + (yPercent * (size.height - (8.dp.toPx() * 2))))
+                        if (index == 0) {
+                            moveTo(x, y)
+                        } else {
+                            lineTo(x, y)
+                        }
+                    }
+                }
+                drawPath(
+                    path = path,
+                    color = lineColor,
+                    style = Stroke(
+                        width = lineWidth.toPx(),
+                    ),
+                )
+            }
+    ) {
+
     }
 }
 
@@ -278,7 +320,7 @@ private fun YAxis(
         if (context.yLabel != null) {
             Text(
                 modifier = Modifier.align(Alignment.CenterVertically)
-                    .padding(horizontal = 4.dp),
+                    .padding(horizontal = 8.dp),
                 text = context.yLabel.toCharArray().joinToString(
                     separator = "\n",
                 ),
@@ -326,7 +368,7 @@ private fun ListGraphPreview() {
         yLabel = "Y Axis"
         plot(
             x = listOf(0f, 1f, 2f, 3f, 4f, 5f, 6f, 7f, 8f, 9f, 10f),
-            y = listOf(0f, 1f, 4f, 9f, 16f, 25f, 36f, 49f, 64f, 81f, 100f),
+            y = listOf(0f, 1f, 64f, 4f, 100f, 16f, 25f, 9f, 36f, 49f, 81f),
         )
     }
     ListGraph(

--- a/presentation/component/src/commonMain/kotlin/com/shunm/android/presentation/component/graph/LineGraph.kt
+++ b/presentation/component/src/commonMain/kotlin/com/shunm/android/presentation/component/graph/LineGraph.kt
@@ -1,5 +1,28 @@
 package com.shunm.android.presentation.component.graph
 
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.drawBehind
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import org.jetbrains.compose.ui.tooling.preview.Preview
+import kotlin.math.ceil
+import kotlin.math.floor
+
 data class LineGraphPoint(
     val x: Float,
     val y: Float,
@@ -10,7 +33,24 @@ data class LineGraphContext(
     val xLabel: String?,
     val yLabel: String?,
     val points: List<LineGraphPoint>,
-)
+) {
+    val scaleCount
+        get() = points.size
+
+    val xRange: ClosedFloatingPointRange<Float>
+        get() = points.minOf { it.x }.let { minX ->
+            points.minOf { it.x }.let { maxX ->
+                floor(minX)..ceil(maxX)
+            }
+        }
+
+    val yRange: ClosedFloatingPointRange<Float>
+        get() = points.minOf { it.y }.let { minY ->
+            points.minOf { it.y }.let { maxY ->
+                floor(minY)..ceil(maxY)
+            }
+        }
+}
 
 class LineGraphContextBuilder {
     var title: String? = null
@@ -34,5 +74,129 @@ class LineGraphContextBuilder {
         xLabel = xLabel,
         yLabel = yLabel,
         points = points.toList(),
+    )
+}
+
+@Composable
+fun rememberLineGraphContext(
+    block: LineGraphContextBuilder.() -> Unit,
+): LineGraphContext {
+    val rememberedBlock by rememberUpdatedState(block)
+    return remember(rememberedBlock) {
+        LineGraphContextBuilder().apply {
+            rememberedBlock()
+        }.build()
+    }
+}
+
+@Composable
+fun ListGraph(
+    context: LineGraphContext,
+    scaleCount: Int = 10,
+    yScaleSpace: Dp = 32.dp,
+    containerColor: Color = MaterialTheme.colorScheme.surface,
+    contentColor: Color = MaterialTheme.colorScheme.onSurface,
+    lineColor: Color = MaterialTheme.colorScheme.primary,
+    borderColor: Color = MaterialTheme.colorScheme.onSurface,
+    borderWidth: Dp = 1.dp,
+) {
+    with(context) {
+        ListGraphOuter(
+            modifier = Modifier.fillMaxWidth().height(yScaleSpace * scaleCount + 16.dp),
+            containerColor = containerColor,
+            contentColor = contentColor,
+            borderColor = borderColor,
+            borderWidth = borderWidth,
+        ) {
+        }
+    }
+}
+
+@Composable
+context(context: LineGraphContext)
+private fun ListGraphOuter(
+    modifier: Modifier = Modifier,
+    containerColor: Color,
+    contentColor: Color,
+    borderColor: Color,
+    borderWidth: Dp,
+    inner: @Composable () -> Unit,
+) {
+    Surface(
+        modifier = modifier,
+        color = containerColor,
+        contentColor = contentColor,
+    ) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+        ) {
+            Column(
+                modifier = Modifier.weight(1f),
+            ) {
+                Box(
+                    Modifier.border(
+                        width = borderWidth,
+                        color = borderColor,
+                    ).padding(
+                        vertical = 8.dp,
+                        horizontal = 16.dp,
+                    ).fillMaxWidth().weight(1f),
+                ) {
+                    inner()
+                }
+                LineGraphXLabel(
+                    borderColor = borderColor,
+                    borderWidth = borderWidth,
+                )
+            }
+        }
+    }
+}
+
+@Composable
+context(context: LineGraphContext)
+fun LineGraphXLabel(
+    borderColor: Color,
+    borderWidth: Dp,
+) {
+    Column(
+        modifier = Modifier.fillMaxWidth(),
+    ) {
+        Box(
+            modifier = Modifier.fillMaxWidth().height(24.dp).drawBehind {
+                val xScale = (size.width - (16.dp.toPx() * 2)) / (context.scaleCount - 1)
+                repeat(context.scaleCount) { count ->
+                    val x = 16.dp.toPx() + (xScale * count)
+                    drawLine(
+                        color = borderColor,
+                        start = Offset(x, 0f),
+                        end = Offset(x, 4.dp.toPx()),
+                        strokeWidth = borderWidth.toPx(),
+                    )
+                }
+            },
+        )
+    }
+}
+
+private sealed interface OrientationScope {
+    object Horizontal : OrientationScope
+    object Vertical : OrientationScope
+}
+
+@Preview
+@Composable
+private fun ListGraphPreview() {
+    val context = rememberLineGraphContext {
+        title = "Sample Line Graph"
+        xLabel = "X Axis"
+        yLabel = "Y Axis"
+        plot(
+            x = listOf(0f, 1f, 2f, 3f, 4f, 5f, 6f, 7f, 8f, 9f, 10f),
+            y = listOf(0f, 1f, 4f, 9f, 16f, 25f, 36f, 49f, 64f, 81f, 100f),
+        )
+    }
+    ListGraph(
+        context = context,
     )
 }

--- a/presentation/component/src/commonMain/kotlin/com/shunm/android/presentation/component/graph/LineGraph.kt
+++ b/presentation/component/src/commonMain/kotlin/com/shunm/android/presentation/component/graph/LineGraph.kt
@@ -3,16 +3,19 @@ package com.shunm.android.presentation.component.graph
 import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.drawBehind
 import androidx.compose.ui.geometry.Offset
@@ -135,6 +138,7 @@ private fun ListGraphOuter(
             Column(
                 modifier = Modifier.weight(1f),
             ) {
+                Title()
                 Box(
                     Modifier.border(
                         width = borderWidth,
@@ -146,7 +150,7 @@ private fun ListGraphOuter(
                 ) {
                     inner()
                 }
-                LineGraphXLabel(
+                XAxis(
                     borderColor = borderColor,
                     borderWidth = borderWidth,
                 )
@@ -157,7 +161,20 @@ private fun ListGraphOuter(
 
 @Composable
 context(context: LineGraphContext)
-private fun LineGraphXLabel(
+private fun ColumnScope.Title() {
+    if (context.title != null) {
+        Text(
+            modifier = Modifier.align(Alignment.CenterHorizontally)
+                .padding(vertical = 4.dp),
+            text = context.title,
+            style = MaterialTheme.typography.labelLarge
+        )
+    }
+}
+
+@Composable
+context(context: LineGraphContext)
+private fun XAxis(
     borderColor: Color,
     borderWidth: Dp,
 ) {
@@ -189,6 +206,14 @@ private fun LineGraphXLabel(
                 }
             },
         )
+        if (context.xLabel != null) {
+            Text(
+                modifier = Modifier.align(Alignment.CenterHorizontally)
+                    .padding(vertical = 4.dp),
+                text = context.xLabel,
+                style = MaterialTheme.typography.labelMedium
+            )
+        }
     }
 }
 

--- a/presentation/component/src/commonMain/kotlin/com/shunm/android/presentation/component/graph/LineGraph.kt
+++ b/presentation/component/src/commonMain/kotlin/com/shunm/android/presentation/component/graph/LineGraph.kt
@@ -17,6 +17,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.drawBehind
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.drawText
+import androidx.compose.ui.text.rememberTextMeasurer
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import org.jetbrains.compose.ui.tooling.preview.Preview
@@ -155,10 +157,12 @@ private fun ListGraphOuter(
 
 @Composable
 context(context: LineGraphContext)
-fun LineGraphXLabel(
+private fun LineGraphXLabel(
     borderColor: Color,
     borderWidth: Dp,
 ) {
+    val textMeasurer = rememberTextMeasurer()
+    val textStyle = MaterialTheme.typography.labelSmall
     Column(
         modifier = Modifier.fillMaxWidth(),
     ) {
@@ -172,6 +176,15 @@ fun LineGraphXLabel(
                         start = Offset(x, 0f),
                         end = Offset(x, 4.dp.toPx()),
                         strokeWidth = borderWidth.toPx(),
+                    )
+                    val text = context.points[count].x.toString()
+                    val textLayoutResult = textMeasurer.measure(
+                        text = text,
+                        style = textStyle,
+                    )
+                    drawText(
+                        textLayoutResult = textLayoutResult,
+                        topLeft = Offset(x - (textLayoutResult.size.width / 2), 8.dp.toPx()),
                     )
                 }
             },

--- a/presentation/component/src/commonMain/kotlin/com/shunm/android/presentation/component/navigation/NavigationBar.kt
+++ b/presentation/component/src/commonMain/kotlin/com/shunm/android/presentation/component/navigation/NavigationBar.kt
@@ -1,0 +1,55 @@
+package com.shunm.android.presentation.component.navigation
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Favorite
+import androidx.compose.material.icons.filled.Home
+import androidx.compose.material.icons.filled.Person
+import androidx.compose.material3.BottomAppBarScrollBehavior
+import androidx.compose.material3.FlexibleBottomAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import org.jetbrains.compose.ui.tooling.preview.Preview
+
+@Composable
+fun ClFlexibleNavigationBar(
+    scrollBehavior: BottomAppBarScrollBehavior? = null,
+    itemStyle: NavigationItemStyle = NavigationItemStyle.Vertical,
+    items: @Composable NavigationBarScope.() -> Unit,
+) {
+    FlexibleBottomAppBar(
+        scrollBehavior = scrollBehavior,
+    ) {
+        val scope = remember(this, itemStyle) {
+            NavigationBarScope(
+                rowScope = this,
+                itemStyle = itemStyle,
+            )
+        }
+        scope.items()
+    }
+}
+
+@Preview
+@Composable
+private fun ClFlexibleNavigationBarPreview() {
+    ClFlexibleNavigationBar {
+        NavigationItem(
+            selected = true,
+            onClick = {},
+            icon = Icons.Default.Home,
+            label = "Home",
+        )
+        NavigationItem(
+            selected = false,
+            onClick = {},
+            icon = Icons.Default.Favorite,
+            label = "Favorite",
+        )
+        NavigationItem(
+            selected = false,
+            onClick = {},
+            icon = Icons.Default.Person,
+            label = "Profile",
+        )
+    }
+}

--- a/presentation/component/src/commonMain/kotlin/com/shunm/android/presentation/component/navigation/NavigationBar.kt
+++ b/presentation/component/src/commonMain/kotlin/com/shunm/android/presentation/component/navigation/NavigationBar.kt
@@ -1,23 +1,31 @@
 package com.shunm.android.presentation.component.navigation
 
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Favorite
 import androidx.compose.material.icons.filled.Home
 import androidx.compose.material.icons.filled.Person
+import androidx.compose.material3.BottomAppBarDefaults
 import androidx.compose.material3.BottomAppBarScrollBehavior
 import androidx.compose.material3.FlexibleBottomAppBar
+import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
+import com.shunm.android.presentation.component.di.Catalogable
 import org.jetbrains.compose.ui.tooling.preview.Preview
 
+@Catalogable
 @Composable
 fun ClFlexibleNavigationBar(
     scrollBehavior: BottomAppBarScrollBehavior? = null,
+    horizontalArrangement: Arrangement.Horizontal =
+        BottomAppBarDefaults.FlexibleHorizontalArrangement,
     itemStyle: NavigationItemStyle = NavigationItemStyle.Vertical,
     items: @Composable NavigationBarScope.() -> Unit,
 ) {
     FlexibleBottomAppBar(
         scrollBehavior = scrollBehavior,
+        horizontalArrangement = horizontalArrangement,
     ) {
         val scope = remember(this, itemStyle) {
             NavigationBarScope(
@@ -32,24 +40,32 @@ fun ClFlexibleNavigationBar(
 @Preview
 @Composable
 private fun ClFlexibleNavigationBarPreview() {
-    ClFlexibleNavigationBar {
-        NavigationItem(
-            selected = true,
-            onClick = {},
-            icon = Icons.Default.Home,
-            label = "Home",
-        )
-        NavigationItem(
-            selected = false,
-            onClick = {},
-            icon = Icons.Default.Favorite,
-            label = "Favorite",
-        )
-        NavigationItem(
-            selected = false,
-            onClick = {},
-            icon = Icons.Default.Person,
-            label = "Profile",
-        )
+    Scaffold(
+        bottomBar = {
+            ClFlexibleNavigationBar(
+                horizontalArrangement = Arrangement.SpaceEvenly,
+            ) {
+                NavigationItem(
+                    selected = true,
+                    onClick = {},
+                    icon = Icons.Default.Home,
+                    label = "Home",
+                )
+                NavigationItem(
+                    selected = false,
+                    onClick = {},
+                    icon = Icons.Default.Favorite,
+                    label = "Favorite",
+                )
+                NavigationItem(
+                    selected = false,
+                    onClick = {},
+                    icon = Icons.Default.Person,
+                    label = "Profile",
+                )
+            }
+        },
+    ) {
+        // do nothing
     }
 }

--- a/presentation/component/src/commonMain/kotlin/com/shunm/android/presentation/component/navigation/NavigationBarItem.kt
+++ b/presentation/component/src/commonMain/kotlin/com/shunm/android/presentation/component/navigation/NavigationBarItem.kt
@@ -1,0 +1,59 @@
+package com.shunm.android.presentation.component.navigation
+
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.NavigationItemIconPosition
+import androidx.compose.material3.ShortNavigationBarItem
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun NavigationBarScope.NavigationItem(
+    selected: Boolean,
+    onClick: () -> Unit,
+    icon: ImageVector,
+    label: String,
+    enabled: Boolean = true,
+) {
+    ShortNavigationBarItem(
+        selected = selected,
+        onClick = onClick,
+        icon = {
+            NavigationItemIcon(icon = icon)
+        },
+        label = {
+            NavigationItemLabel(label = label)
+        },
+        iconPosition = when (itemStyle) {
+            NavigationItemStyle.Vertical -> NavigationItemIconPosition.Top
+            NavigationItemStyle.Horizontal -> NavigationItemIconPosition.Start
+        },
+        enabled = enabled,
+    )
+}
+
+@Composable
+private fun NavigationItemLabel(
+    label: String,
+) {
+    Text(
+        text = label,
+        maxLines = 1,
+        style = MaterialTheme.typography.labelMedium,
+    )
+}
+
+@Composable
+private fun NavigationItemIcon(
+    icon: ImageVector,
+) {
+    Icon(
+        modifier = Modifier.size(24.dp),
+        imageVector = icon,
+        contentDescription = null,
+    )
+}

--- a/presentation/component/src/commonMain/kotlin/com/shunm/android/presentation/component/navigation/NavigationBarProvider.kt
+++ b/presentation/component/src/commonMain/kotlin/com/shunm/android/presentation/component/navigation/NavigationBarProvider.kt
@@ -1,2 +1,73 @@
 package com.shunm.android.presentation.component.navigation
 
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Favorite
+import androidx.compose.material.icons.filled.Home
+import androidx.compose.material.icons.filled.Person
+import androidx.compose.material.icons.filled.Search
+import androidx.compose.material.icons.filled.Settings
+import androidx.compose.runtime.Composable
+import com.shunm.android.presentation.component.di.CatalogProvider
+import com.shunm.android.presentation.component.di.Provider
+
+@CatalogProvider
+internal class NavigationItemStyleProvider : Provider<NavigationItemStyle> {
+    override fun provide(): List<NavigationItemStyle> {
+        return NavigationItemStyle.entries
+    }
+}
+
+@CatalogProvider
+internal class NavigationItemsCountProvider : Provider<@Composable NavigationBarScope.() -> Unit> {
+    override fun provide(): List<@Composable NavigationBarScope.() -> Unit> {
+        val items = listOf<@Composable NavigationBarScope.() -> Unit>(
+            {
+                NavigationItem(
+                    selected = true,
+                    onClick = {},
+                    icon = Icons.Default.Home,
+                    label = "Home",
+                )
+            },
+            {
+                NavigationItem(
+                    selected = false,
+                    onClick = {},
+                    icon = Icons.Default.Favorite,
+                    label = "Favorite",
+                )
+            },
+            {
+                NavigationItem(
+                    selected = false,
+                    onClick = {},
+                    icon = Icons.Default.Person,
+                    label = "Profile",
+                )
+            },
+            {
+                NavigationItem(
+                    selected = false,
+                    onClick = {},
+                    icon = Icons.Default.Search,
+                    label = "Search",
+                )
+            },
+            {
+                NavigationItem(
+                    selected = false,
+                    onClick = {},
+                    icon = Icons.Default.Settings,
+                    label = "Settings",
+                )
+            },
+        )
+        return (3..5).map {
+            {
+                items.take(it).forEach { item ->
+                    item()
+                }
+            }
+        }
+    }
+}

--- a/presentation/component/src/commonMain/kotlin/com/shunm/android/presentation/component/navigation/NavigationBarProvider.kt
+++ b/presentation/component/src/commonMain/kotlin/com/shunm/android/presentation/component/navigation/NavigationBarProvider.kt
@@ -1,0 +1,2 @@
+package com.shunm.android.presentation.component.navigation
+

--- a/presentation/component/src/commonMain/kotlin/com/shunm/android/presentation/component/navigation/NavigationBarScope.kt
+++ b/presentation/component/src/commonMain/kotlin/com/shunm/android/presentation/component/navigation/NavigationBarScope.kt
@@ -1,0 +1,13 @@
+package com.shunm.android.presentation.component.navigation
+
+import androidx.compose.foundation.layout.RowScope
+
+enum class NavigationItemStyle {
+    Vertical,
+    Horizontal,
+}
+
+data class NavigationBarScope(
+    private val rowScope: RowScope,
+    val itemStyle: NavigationItemStyle,
+) : RowScope by rowScope

--- a/presentation/component/src/commonMain/kotlin/com/shunm/android/presentation/component/tab/TabItem.kt
+++ b/presentation/component/src/commonMain/kotlin/com/shunm/android/presentation/component/tab/TabItem.kt
@@ -1,0 +1,43 @@
+package com.shunm.android.presentation.component.tab
+
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Tab
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun TabItem(
+    selected: Boolean,
+    onClick: () -> Unit,
+    enabled: Boolean = true,
+    imageVector: ImageVector? = null,
+    text: String? = null,
+) {
+    Tab(
+        selected = selected,
+        onClick = onClick,
+        enabled = enabled,
+        icon = if (imageVector != null) {
+            {
+                Icon(
+                    modifier = Modifier.size(24.dp),
+                    imageVector = imageVector,
+                    contentDescription = null,
+                )
+            }
+        } else {
+            null
+        },
+        text = if (text != null) {
+            {
+                Text(text = text)
+            }
+        } else {
+            null
+        },
+    )
+}

--- a/presentation/component/src/commonMain/kotlin/com/shunm/android/presentation/component/tab/TabRow.kt
+++ b/presentation/component/src/commonMain/kotlin/com/shunm/android/presentation/component/tab/TabRow.kt
@@ -99,7 +99,7 @@ private fun getTabRowType(
 
 @Preview
 @Composable
-private fun TabRowPreview() {
+private fun ClTabRowPreview() {
     ClTabRow(
         isPrimary = true,
         selected = 0,

--- a/presentation/component/src/commonMain/kotlin/com/shunm/android/presentation/component/tab/TabRow.kt
+++ b/presentation/component/src/commonMain/kotlin/com/shunm/android/presentation/component/tab/TabRow.kt
@@ -1,0 +1,116 @@
+package com.shunm.android.presentation.component.tab
+
+import androidx.compose.material3.PrimaryScrollableTabRow
+import androidx.compose.material3.PrimaryTabRow
+import androidx.compose.material3.SecondaryScrollableTabRow
+import androidx.compose.material3.SecondaryTabRow
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
+import org.jetbrains.compose.ui.tooling.preview.Preview
+
+@Composable
+fun <T> ClTabRow(
+    selected: T,
+    isPrimary: Boolean = true,
+    isScrollable: Boolean = true,
+    tabs: TabRowScope.() -> TabRowContext<T>,
+) {
+    val rememberedTabs by rememberUpdatedState(tabs)
+    val context = remember(rememberedTabs) {
+        TabRowScope.rememberedTabs()
+    }
+    val tabRowType = remember(
+        isPrimary,
+        isScrollable,
+    ) {
+        getTabRowType(
+            isPrimary = isPrimary,
+            isScrollable = isScrollable,
+        )
+    }
+
+    when (tabRowType) {
+        TabRowType.Primary -> {
+            PrimaryTabRow(
+                selectedTabIndex = context.items.indexOf(selected),
+                tabs = {
+                    context.items.forEach { item ->
+                        context.itemContent(TabItemScope(isSelected = item == selected), item)
+                    }
+                },
+            )
+        }
+
+        TabRowType.PrimaryScrollable -> {
+            PrimaryScrollableTabRow(
+                selectedTabIndex = context.items.indexOf(selected),
+                tabs = {
+                    context.items.forEach { item ->
+                        context.itemContent(TabItemScope(isSelected = item == selected), item)
+                    }
+                },
+            )
+        }
+
+        TabRowType.Secondary -> {
+            SecondaryTabRow(
+                selectedTabIndex = context.items.indexOf(selected),
+                tabs = {
+                    context.items.forEach { item ->
+                        context.itemContent(TabItemScope(isSelected = item == selected), item)
+                    }
+                },
+            )
+        }
+
+        TabRowType.SecondaryScrollable -> {
+            SecondaryScrollableTabRow(
+                selectedTabIndex = context.items.indexOf(selected),
+                tabs = {
+                    context.items.forEach { item ->
+                        context.itemContent(TabItemScope(isSelected = item == selected), item)
+                    }
+                },
+            )
+        }
+    }
+}
+
+private sealed interface TabRowType {
+    object Primary : TabRowType
+    object PrimaryScrollable : TabRowType
+    object Secondary : TabRowType
+    object SecondaryScrollable : TabRowType
+}
+
+private fun getTabRowType(
+    isPrimary: Boolean,
+    isScrollable: Boolean,
+): TabRowType {
+    return when {
+        isPrimary && isScrollable -> TabRowType.PrimaryScrollable
+        isPrimary && !isScrollable -> TabRowType.Primary
+        !isPrimary && isScrollable -> TabRowType.SecondaryScrollable
+        else -> TabRowType.Secondary
+    }
+}
+
+@Preview
+@Composable
+private fun TabRowPreview() {
+    ClTabRow(
+        isPrimary = true,
+        selected = 0,
+        tabs = {
+            items(listOf(0, 1, 2)) { item ->
+                TabItem(
+                    selected = isSelected,
+                    onClick = {},
+                    text = "Tab $item",
+                )
+            }
+        },
+    )
+}

--- a/presentation/component/src/commonMain/kotlin/com/shunm/android/presentation/component/tab/TabRowScope.kt
+++ b/presentation/component/src/commonMain/kotlin/com/shunm/android/presentation/component/tab/TabRowScope.kt
@@ -1,0 +1,21 @@
+package com.shunm.android.presentation.component.tab
+
+import androidx.compose.runtime.Composable
+
+data object TabRowScope {
+    fun <T> items(items: List<T>, itemContent: @Composable TabItemScope<T>.(item: T) -> Unit): TabRowContext<T> {
+        return TabRowContext(
+            items = items,
+            itemContent = itemContent,
+        )
+    }
+}
+
+data class TabRowContext<T>(
+    val items: List<T>,
+    val itemContent: @Composable TabItemScope<T>.(item: T) -> Unit,
+)
+
+data class TabItemScope<T>(
+    val isSelected: Boolean,
+)

--- a/presentation/shared/src/commonMain/kotlin/com/shunm/android/presentation/shared/ext/LayoutExt.kt
+++ b/presentation/shared/src/commonMain/kotlin/com/shunm/android/presentation/shared/ext/LayoutExt.kt
@@ -1,0 +1,40 @@
+package com.shunm.android.presentation.shared.ext
+
+import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.RowScope
+
+inline fun <T> ColumnScope.items(
+    items: List<T>,
+    itemContent: ColumnScope.(item: T) -> Unit,
+) {
+    items.forEach {
+        itemContent(it)
+    }
+}
+
+inline fun <T> ColumnScope.itemsIndexed(
+    items: List<T>,
+    itemContent: ColumnScope.(index: Int, item: T) -> Unit,
+) {
+    items.forEachIndexed { index, item ->
+        itemContent(index, item)
+    }
+}
+
+inline fun <T> RowScope.items(
+    items: List<T>,
+    itemContent: RowScope.(item: T) -> Unit,
+) {
+    items.forEach {
+        itemContent(it)
+    }
+}
+
+inline fun <T> RowScope.itemsIndexed(
+    items: List<T>,
+    itemContent: RowScope.(index: Int, item: T) -> Unit,
+) {
+    items.forEachIndexed { index, item ->
+        itemContent(index, item)
+    }
+}


### PR DESCRIPTION
This pull request introduces two new UI components for the project: a flexible navigation bar with customizable items and a reusable tab row with selectable tabs. Both features are implemented using Jetpack Compose and are designed for easy integration and preview. The navigation bar supports vertical and horizontal item layouts, while the tab row supports both primary/secondary and scrollable/non-scrollable variants.

**Navigation Bar Enhancements:**

* Added a flexible navigation bar component (`ClFlexibleNavigationBar`) that supports customizable arrangements and item styles (vertical/horizontal), with composable item slots for dynamic content. (`NavigationBar.kt`, [presentation/component/src/commonMain/kotlin/com/shunm/android/presentation/component/navigation/NavigationBar.ktR1-R71](diffhunk://#diff-7946b70a946009825175f075979b006782229761f05b096e3dbab6a72a718ea2R1-R71))
* Implemented navigation bar item support (`NavigationItem`) with icon and label, including style configuration for icon position and label appearance. (`NavigationBarItem.kt`, [presentation/component/src/commonMain/kotlin/com/shunm/android/presentation/component/navigation/NavigationBarItem.ktR1-R59](diffhunk://#diff-152c83b0d56108690d4f4f7db0b5dada9217f5a1d749b09cd17f80cfa9d92a62R1-R59))
* Provided scope and style management for navigation bar items via `NavigationBarScope` and `NavigationItemStyle` enum. (`NavigationBarScope.kt`, [presentation/component/src/commonMain/kotlin/com/shunm/android/presentation/component/navigation/NavigationBarScope.ktR1-R13](diffhunk://#diff-823a5c5f5bdd319bac5fefd3b071a13ebae3e281ca681baf80cf997f05c703d2R1-R13))
* Added providers for navigation item styles and item count, facilitating catalog integration and previewing multiple navigation bar configurations. (`NavigationBarProvider.kt`, [presentation/component/src/commonMain/kotlin/com/shunm/android/presentation/component/navigation/NavigationBarProvider.ktR1-R73](diffhunk://#diff-b249939c4e9cb98d300fb7a24151b5a61b2c8993e906680b16e8e976eec2c54fR1-R73))

**Tab Row Component:**

* Introduced a generic tab row component (`ClTabRow`) supporting primary/secondary and scrollable/non-scrollable layouts, with composable tab content and selection logic. (`TabRow.kt`, [presentation/component/src/commonMain/kotlin/com/shunm/android/presentation/component/tab/TabRow.ktR1-R116](diffhunk://#diff-3fdf50a4a84f8fc7451bd8601447d66de0abc7c34f5d40d4a42c6af408da2cfcR1-R116))
* Added a reusable tab item composable (`TabItem`) with optional icon and label, supporting selection and enable/disable states. (`TabItem.kt`, [presentation/component/src/commonMain/kotlin/com/shunm/android/presentation/component/tab/TabItem.ktR1-R43](diffhunk://#diff-609896b9fa95222c33be9dadbd0c84646560140c10f76241fb461f05e083a665R1-R43))
* Defined scope and context for tab row items, enabling flexible tab rendering and selection management. (`TabRowScope.kt`, [presentation/component/src/commonMain/kotlin/com/shunm/android/presentation/component/tab/TabRowScope.ktR1-R21](diffhunk://#diff-1325daa063fb55d52f7efefb47428b60cedc9a1f7cb93dda2b10702dabed7d43R1-R21))

**Graph Component:**

* Added a customizable line graph composable (`LineGraph`) with context builder, supporting axis labels, title, and scale configuration for displaying data points. (`LineGraph.kt`, [presentation/component/src/commonMain/kotlin/com/shunm/android/presentation/component/graph/LineGraph.ktR1-R375](diffhunk://#diff-c9a8a2cda83e9b7e1c9c7548cc63f435e7897d096898845c129b20af3e93443aR1-R375))